### PR TITLE
Estruturar projeto do widget de lead do WhatsApp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Dependencies
+node_modules/
+
+# Build output
+/dist/
+
+# Temporary files
+.DS_Store
+*.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# teste
+# WhatsApp Lead Widget
+
+Widget pronto para uso que capta informações de leads (nome, e-mail, consentimento e dados extras) antes de abrir uma conversa no WhatsApp. O componente foi pensado para ser facilmente incorporado em qualquer site estático ou aplicação existente.
+
+## Recursos
+
+- Botão flutuante com modal personalizado.
+- Formulário com validação básica de nome e e-mail.
+- Envio opcional dos dados para um endpoint (por exemplo, Google Apps Script).
+- Registro de evento no Google Analytics 4 (opcional).
+- Interceptação automática de links WhatsApp existentes na página.
+- API pública para abrir o widget e alterar o número dinamicamente.
+
+## Como usar
+
+1. Copie o arquivo [`src/whatsapp-lead-widget.js`](src/whatsapp-lead-widget.js) para o seu projeto ou carregue-o via CDN próprio.
+2. Inclua o script no final do `body` da sua página.
+3. Em seguida, inicialize o widget com a configuração desejada:
+
+```html
+<script src="/caminho/para/whatsapp-lead-widget.js"></script>
+<script>
+  WhatsAppLeadWidget.init({
+    scriptURL: "https://script.google.com/macros/s/SEU_SCRIPT/exec",
+    whatsappNumber: "5511999999999",
+    brandImage: "https://exemplo.com/logo.png",
+    brandTitle: "Minha Marca",
+    brandStatus: "online",
+    privacyPolicyUrl: "https://exemplo.com/politica",
+    interceptLinks: true,
+    enableGA4: true,
+    texts: {
+      welcome: "Olá! Para continuarmos, informe seu e-mail :)",
+      nameLabel: "Nome *",
+      emailLabel: "Email *",
+      consentLabel: "Aceito receber comunicados",
+      submit: "Iniciar conversa",
+      required: "Por favor, preencha Nome e Email."
+    },
+    theme: {
+      primary: "#036d5f",
+      primaryHover: "#02594d",
+      bubbleBg: "#efeae2",
+      inputBg: "#e7ffe7"
+    },
+    extraFields: {
+      origem: "Website - WhatsApp Widget"
+    }
+  });
+</script>
+```
+
+> Observação: o número do WhatsApp deve estar no formato `DDI + DDD + número`, contendo apenas dígitos.
+
+## Exemplo
+
+Um exemplo completo está disponível em [`example/index.html`](example/index.html). Abra o arquivo direto no navegador para testar a experiência.
+
+## Personalização
+
+- **Texts**: altere rótulos, mensagens e textos exibidos no modal.
+- **Theme**: personalize cores de destaque, hover e elementos do formulário.
+- **Interceptação de links**: habilite `interceptLinks: true` para que links `wa.me`, `api.whatsapp.com/send` e `whatsapp://send` abram o widget antes da conversa.
+- **Campos extras**: adicione pares chave/valor em `extraFields` para enviar metadados ao seu backend.
+- **API pública**: após inicializar o widget, é possível utilizar `WhatsAppLeadWidget.open(number?)`, `WhatsAppLeadWidget.setNumber(number)` e `WhatsAppLeadWidget.destroy()`.
+
+## Desenvolvimento
+
+- O código principal está em `src/whatsapp-lead-widget.js` e não depende de bundlers.
+- Para visualizar alterações rapidamente, abra `example/index.html` com Live Server ou semelhante.
+- Para publicar em um CDN, basta minificar o arquivo se desejar e disponibilizá-lo.
+
+## Licença
+
+[MIT](LICENSE)

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WhatsApp Lead Widget - Exemplo</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+    <style>
+      body {
+        font-family: "Open Sans", Arial, sans-serif;
+        background: #f5f5f5;
+        color: #2f353d;
+        margin: 0;
+        padding: 0 24px 120px;
+      }
+      header {
+        max-width: 960px;
+        margin: 60px auto 24px;
+        text-align: center;
+      }
+      header h1 {
+        font-size: 2.5rem;
+        margin-bottom: 16px;
+      }
+      header p {
+        font-size: 1.125rem;
+        margin: 0;
+      }
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+        background: #fff;
+        border-radius: 12px;
+        padding: 32px;
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+      }
+      main h2 {
+        margin-top: 0;
+      }
+      code {
+        background: #0f172a;
+        color: #f8fafc;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 0.95rem;
+      }
+      section + section {
+        margin-top: 24px;
+      }
+      .links {
+        margin-top: 24px;
+      }
+      .links a {
+        display: inline-block;
+        margin-right: 12px;
+        color: #036d5f;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>WhatsApp Lead Widget</h1>
+      <p>Capture informações de leads antes de iniciar uma conversa no WhatsApp.</p>
+    </header>
+    <main>
+      <section>
+        <h2>Como testar</h2>
+        <p>
+          Abra o arquivo <code>example/index.html</code> em seu navegador preferido. Clique no botão do WhatsApp no canto da tela,
+          preencha as informações e veja o fluxo completo do widget.
+        </p>
+      </section>
+      <section>
+        <h2>Configuração</h2>
+        <p>
+          O arquivo de configuração está logo após o script principal. Ajuste as propriedades conforme necessidade, incluindo
+          número do WhatsApp, rótulos, cores e endpoint para receber os dados capturados.
+        </p>
+      </section>
+      <section class="links">
+        <a href="https://wa.me/5511999999999" target="_blank" rel="noopener">Abrir conversa direta (interceptada)</a>
+        <a href="#" data-skip-wa-widget>Link ignorando o widget</a>
+      </section>
+    </main>
+
+    <script src="../src/whatsapp-lead-widget.js"></script>
+    <script>
+      WhatsAppLeadWidget.init({
+        scriptURL: "https://script.google.com/macros/s/SEU_SCRIPT/exec",
+        whatsappNumber: "5511999999999",
+        brandImage: "https://placehold.co/80x80",
+        brandTitle: "Minha Marca",
+        brandStatus: "online agora",
+        privacyPolicyUrl: "https://exemplo.com/politica",
+        interceptLinks: true,
+        enableGA4: true,
+        texts: {
+          welcome: "Olá! Para continuarmos, informe seu e-mail :)",
+          nameLabel: "Nome *",
+          emailLabel: "Email *",
+          consentLabel: "Aceito receber comunicados",
+          submit: "Iniciar conversa",
+          required: "Por favor, preencha Nome e Email."
+        },
+        theme: {
+          primary: "#036d5f",
+          primaryHover: "#02594d",
+          bubbleBg: "#efeae2",
+          inputBg: "#e7ffe7"
+        },
+        extraFields: {
+          origem: "Website - WhatsApp Widget"
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/whatsapp-lead-widget.js
+++ b/src/whatsapp-lead-widget.js
@@ -1,0 +1,307 @@
+/*! WhatsApp Lead Widget - Generic v1.0 | MIT */
+(function(root){
+  "use strict";
+
+  var _instance = null;
+
+  function toDigits(s){ return (String(s||"").match(/\d+/g)||[]).join(""); }
+  function $(sel, ctx){ return (ctx||document).querySelector(sel); }
+  function createEl(tag, attrs){ var el=document.createElement(tag); if(attrs){ Object.keys(attrs).forEach(function(k){ el.setAttribute(k, attrs[k]); }); } return el; }
+
+  function mergeDeep(target, source){
+    var t = Object(target), s = Object(source);
+    Object.keys(s).forEach(function(k){
+      if (s[k] && typeof s[k] === "object" && !Array.isArray(s[k])) {
+        t[k] = mergeDeep(t[k] || {}, s[k]);
+      } else {
+        t[k] = s[k];
+      }
+    });
+    return t;
+  }
+
+  var DEFAULTS = {
+    scriptURL: "",
+    whatsappNumber: "",
+    brandImage: "",
+    brandTitle: "Minha Marca",
+    brandStatus: "online",
+    privacyPolicyUrl: "#",
+    interceptLinks: false,
+    enableGA4: false,
+    texts: {
+      welcome: "Olá! Para continuarmos, informe seu e-mail :)",
+      nameLabel: "Nome *",
+      emailLabel: "Email *",
+      consentLabel: "Aceito receber comunicados",
+      submit: "Iniciar conversa",
+      required: "Por favor, preencha Nome e Email."
+    },
+    theme: {
+      primary: "#036d5f",
+      primaryHover: "#02594d",
+      bubbleBg: "#efeae2",
+      inputBg: "#e7ffe7"
+    },
+    ipLookupTimeoutMs: 800,
+    backgroundPattern: "https://user-images.githubusercontent.com/15075759/28719144-86dc0f70-73b1-11e7-911d-60d70fcded21.png",
+    extraFields: {},
+    attachTo: "body"
+  };
+
+  function Widget(userCfg){
+    this.cfg = mergeDeep(JSON.parse(JSON.stringify(DEFAULTS)), userCfg || {});
+    this.cfg.whatsappNumber = toDigits(this.cfg.whatsappNumber);
+    this.runtimeNumber = this.cfg.whatsappNumber;
+
+    if (!this.cfg.whatsappNumber) {
+      console.warn("[WhatsAppLeadWidget] 'whatsappNumber' é obrigatório.");
+    }
+    this.container = document.querySelector(this.cfg.attachTo) || document.body;
+    this._build();
+    if (this.cfg.interceptLinks) this._setupLinkInterceptor();
+  }
+
+  Widget.prototype._injectCSS = function(){
+    var c = this.cfg, t = c.theme;
+    var css = `
+      .wlw-modal { position: fixed; bottom: 20px; right: 20px; width: 340px;
+        border: 1px solid #cacaca; border-radius: 6px; overflow: hidden;
+        display: none; z-index: 9999; font-family: "Open Sans", Arial, sans-serif; background: #fff; }
+      .wlw-header { background-color: ${t.primary}; color: #fff; padding: 10px; display: flex; align-items: center; position: relative; }
+      .wlw-avatar { width: 40px; height: 40px; border-radius: 50%; margin-right: 10px; object-fit: cover; }
+      .wlw-title { font-size: 18px; font-weight: 700; margin-bottom: 2px; }
+      .wlw-status { font-size: 13px; color: #c8f8c8; }
+      .wlw-close { position: absolute; top: 10px; right: 10px; cursor: pointer; font-size: 20px; color: #fff; }
+      .wlw-body { background: ${t.bubbleBg} url('${c.backgroundPattern}') repeat; background-size: 300px; padding: 10px; }
+      .wlw-msg { background: #fff; border: 1px solid #cacaca; border-radius: 6px; padding: 10px; color: #4a4a4a; margin-bottom: 10px; font-size: 14px; }
+      .wlw-form { display: flex; flex-direction: column; }
+      .wlw-label { font-size: 14px; font-weight: 700; margin-bottom: 5px; }
+      .wlw-input { background-color: ${t.inputBg}; border: 1px solid #cacaca; border-radius: 6px; padding: 8px; margin-bottom: 10px;
+        width: 100%; box-sizing: border-box; font-size: 14px; color: #4a4a4a; }
+      .wlw-consent { display: flex; align-items: center; margin-bottom: 10px; font-size: 14px; color: #4a4a4a; }
+      .wlw-submit { background-color: ${t.primary}; color: #fff; border: none; border-radius: 6px; padding: 10px; font-size: 16px; cursor: pointer; }
+      .wlw-submit:hover { background-color: ${t.primaryHover}; }
+      .wlw-fab { position: fixed; z-index: 999; bottom: 20px; right: 20px; cursor: pointer; border: 0; background: transparent; padding: 0; }
+      .wlw-fab img { height: 60px; width: auto; }
+      .wlw-spinner { display: inline-block; width: 16px; height: 16px; border: 2px solid rgba(255,255,255,0.6);
+        border-radius: 50%; border-top-color: #fff; animation: wlwspin 0.6s linear infinite; margin-left: 5px; }
+      @keyframes wlwspin { to { transform: rotate(360deg); } }
+      .wlw-footer { margin-top: 10px; font-size: 12px; text-align: center; color: #666; }
+      .wlw-footer a { color: #666; text-decoration: none; }
+      .wlw-footer a:hover { text-decoration: underline; }
+      @media (max-width: 420px) { .wlw-modal { width: calc(100% - 40px); right: 20px; left: 20px; } }
+    `;
+    var style = createEl("style");
+    style.textContent = css;
+    document.head.appendChild(style);
+  };
+
+  Widget.prototype._build = function(){
+    var c = this.cfg;
+
+    this._injectCSS();
+
+    this.fab = createEl("button", { type:"button", class:"wlw-fab", "aria-label":"Abrir atendimento no WhatsApp" });
+    this.fab.innerHTML = '<img src="https://upload.wikimedia.org/wikipedia/commons/6/6b/WhatsApp.svg" alt="WhatsApp">';
+    this.container.appendChild(this.fab);
+
+    this.modal = createEl("div", { class:"wlw-modal", role:"dialog", "aria-modal":"true" });
+    this.modal.innerHTML = [
+      '<div class="wlw-header">',
+        '<img class="wlw-avatar" src="'+(c.brandImage||"")+'" alt="'+(c.brandTitle||"")+'">',
+        '<div>',
+          '<div class="wlw-title">'+(c.brandTitle||"")+'</div>',
+          '<div class="wlw-status">'+(c.brandStatus||"")+'</div>',
+        '</div>',
+        '<div class="wlw-close" aria-label="Fechar">×</div>',
+      '</div>',
+      '<div class="wlw-body">',
+        '<div class="wlw-msg">'+(c.texts.welcome||"")+'</div>',
+        '<form class="wlw-form" novalidate>',
+          '<label class="wlw-label" for="wlw-name">'+(c.texts.nameLabel||"Nome *")+'</label>',
+          '<input id="wlw-name" class="wlw-input" type="text" name="nome" required placeholder="Seu nome" autocomplete="name">',
+          '<label class="wlw-label" for="wlw-email">'+(c.texts.emailLabel||"Email *")+'</label>',
+          '<input id="wlw-email" class="wlw-input" type="email" name="email" required placeholder="seu@email" autocomplete="email" inputmode="email">',
+          '<div class="wlw-consent">',
+            '<input id="wlw-consent" type="checkbox" name="consent">',
+            '<label for="wlw-consent" style="margin:0; font-weight: normal;">'+(c.texts.consentLabel||"Aceito receber comunicados")+'</label>',
+          '</div>',
+          '<button type="submit" class="wlw-submit">'+(c.texts.submit||"Iniciar conversa")+'</button>',
+        '</form>',
+        '<div class="wlw-footer">',
+          (c.privacyPolicyUrl ? '<a href="'+c.privacyPolicyUrl+'" target="_blank" rel="noopener">Política de Privacidade</a>' : ''),
+          '<span> '+(c.privacyPolicyUrl ? ' | ' : '')+'Powered by <a href="https://www.agenciaregex.com/" target="_blank" rel="noopener">Agência Regex</a></span>',
+        '</div>',
+      '</div>'
+    ].join("");
+    this.container.appendChild(this.modal);
+
+    var self = this;
+    this.fab.addEventListener("click", function(){ self.open(); });
+    $('.wlw-close', this.modal).addEventListener("click", function(){ self.modal.style.display="none"; });
+    $('.wlw-form', this.modal).addEventListener("submit", this._onSubmit.bind(this));
+
+    root.WhatsAppLeadWidget = root.WhatsAppLeadWidget || {};
+    root.WhatsAppLeadWidget.open = this.open.bind(this);
+    root.WhatsAppLeadWidget.setNumber = this.setNumber.bind(this);
+    root.WhatsAppLeadWidget.destroy = this.destroy.bind(this);
+  };
+
+  Widget.prototype._trackGA = function(){
+    if (!this.cfg.enableGA4) return;
+    try {
+      if (typeof root.gtag === "function") {
+        root.gtag("event", "whatsappClick", {
+          event_category: "engagement",
+          event_label: "WhatsApp Form",
+          value: 1
+        });
+      } else {
+        root.dataLayer = root.dataLayer || [];
+        root.dataLayer.push({
+          event: "whatsappClick",
+          eventCategory: "engagement",
+          eventLabel: "WhatsApp Form",
+          value: 1
+        });
+      }
+    } catch(_) {}
+  };
+
+  Widget.prototype._getIP = function(timeoutMs){
+    var ms = typeof timeoutMs === "number" ? timeoutMs : this.cfg.ipLookupTimeoutMs;
+    return new Promise(function(resolve){
+      var done=false;
+      var t=setTimeout(function(){ if(!done){done=true;resolve("");}}, ms);
+      fetch("https://api.ipify.org?format=json").then(function(r){return r.json();}).then(function(j){
+        if(!done){done=true;clearTimeout(t);resolve(j.ip||"");}
+      }).catch(function(){ if(!done){done=true;clearTimeout(t);resolve("");}});
+    });
+  };
+
+  Widget.prototype._postLead = function(payload){
+    if (!this.cfg.scriptURL) return Promise.resolve("skip-post");
+    var fd = new FormData();
+    Object.keys(payload).forEach(function(k){ if (payload[k] != null) fd.append(k, payload[k]); });
+    return fetch(this.cfg.scriptURL, { method:"POST", body: fd }).then(function(r){ return r.text(); });
+  };
+
+  Widget.prototype._onSubmit = function(e){
+    e.preventDefault();
+    var name = $('#wlw-name', this.modal).value.trim();
+    var email = $('#wlw-email', this.modal).value.trim();
+    var consent = $('#wlw-consent', this.modal).checked ? "Sim" : "Não";
+
+    if (!name || !email) { alert(this.cfg.texts.required); return; }
+
+    var btn = $('.wlw-submit', this.modal);
+    btn.disabled = true;
+    btn.innerHTML = (this.cfg.texts.submit || "Iniciar conversa")+' <span class="wlw-spinner"></span>';
+
+    var msg = "Olá! Meu nome é " + name + ". Email: " + email + (consent === "Sim" ? ". Aceitou receber comunicados." : "");
+    var encoded = encodeURIComponent(msg);
+
+    var number = this.runtimeNumber || this.cfg.whatsappNumber;
+    var waUrl = "https://wa.me/" + number + "?text=" + encoded;
+    var win = window.open(waUrl, "_blank");
+
+    var payload = mergeDeep({
+      nome: name,
+      email: email,
+      consent: consent,
+      timestamp: new Date().toLocaleString("pt-BR", { timeZone: "America/Sao_Paulo" }),
+      userAgent: navigator.userAgent || "",
+      pageUrl: location.href
+    }, (this.cfg.extraFields || {}));
+
+    var self = this;
+    this._getIP().then(function(ip){
+      if (ip) payload.userIP = ip;
+      return self._postLead(payload);
+    }).then(function(){
+      self._trackGA();
+      self.modal.style.display = "none";
+      btn.disabled = false;
+      btn.textContent = (self.cfg.texts.submit || "Iniciar conversa");
+      $('.wlw-form', self.modal).reset();
+    }).catch(function(err){
+      console.error("[WhatsAppLeadWidget] Erro ao enviar dados:", err);
+      alert("Ocorreu um erro ao enviar os dados. Tente novamente.");
+      btn.disabled = false;
+      btn.textContent = (self.cfg.texts.submit || "Iniciar conversa");
+      if (win) { try { win.close(); } catch(_){} }
+    });
+  };
+
+  Widget.prototype._setupLinkInterceptor = function(){
+    var self = this;
+
+    function isWhatsAppLink(href){
+      if (!href) return false;
+      return /wa\.me\/\d+/i.test(href)
+          || /api\.whatsapp\.com\/send/i.test(href)
+          || /^whatsapp:\/\/send/i.test(href);
+    }
+    function extractNumber(href){
+      if (!href) return "";
+      var m1 = href.match(/wa\.me\/(\d+)/i);                         if (m1 && m1[1]) return toDigits(m1[1]);
+      var m2 = href.match(/[?&#]phone=([^&#]+)/i);                    if (m2 && m2[1]) return toDigits(decodeURIComponent(m2[1]));
+      var m3 = href.match(/^whatsapp:\/\/send\?.*?phone=([^&#]+)/i);  if (m3 && m3[1]) return toDigits(decodeURIComponent(m3[1]));
+      return "";
+    }
+
+    document.addEventListener("click", function(e){
+      var a = e.target.closest && e.target.closest("a[href]");
+      if (!a) return;
+      if (a.hasAttribute("data-skip-wa-widget")) return;
+      var href = a.getAttribute("href") || "";
+      if (!isWhatsAppLink(href)) return;
+      e.preventDefault();
+      var num = extractNumber(href);
+      self.open(num || undefined);
+    }, true);
+  };
+
+  Widget.prototype.open = function(number){
+    if (number) this.runtimeNumber = toDigits(number);
+    else this.runtimeNumber = this.cfg.whatsappNumber;
+    this.modal.style.display = "block";
+    var nameEl = $('#wlw-name', this.modal);
+    if (nameEl) nameEl.focus();
+  };
+
+  Widget.prototype.setNumber = function(number){
+    this.runtimeNumber = toDigits(number);
+  };
+
+  Widget.prototype.destroy = function(){
+    try {
+      this.fab && this.fab.remove();
+      this.modal && this.modal.remove();
+    } catch(_) {}
+    delete root.WhatsAppLeadWidget.open;
+    delete root.WhatsAppLeadWidget.setNumber;
+    delete root.WhatsAppLeadWidget.destroy;
+    _instance = null;
+  };
+
+  root.WhatsAppLeadWidget = root.WhatsAppLeadWidget || {};
+  root.WhatsAppLeadWidget.init = function(userCfg){
+    if (_instance) {
+      if (userCfg && userCfg.whatsappNumber) _instance.setNumber(userCfg.whatsappNumber);
+      return _instance;
+    }
+
+    function start(){
+      _instance = new Widget(userCfg);
+      return _instance;
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", start);
+    } else {
+      start();
+    }
+  };
+
+})(window);


### PR DESCRIPTION
## Summary
- organize the WhatsApp lead widget source into a dedicated `src` directory and provide a runnable example page
- document configuration, customization, and licensing details for publishing the widget on GitHub
- add repository housekeeping files such as a `.gitignore` and MIT license

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68dbae6ccef083289ff38746adf04c5a