### PR TITLE
Improve widget accessibility and robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Um exemplo completo está disponível em [`example/index.html`](example/index.ht
 - **Theme**: personalize cores de destaque, hover e elementos do formulário.
 - **Interceptação de links**: habilite `interceptLinks: true` para que links `wa.me`, `api.whatsapp.com/send` e `whatsapp://send` abram o widget antes da conversa.
 - **Campos extras**: adicione pares chave/valor em `extraFields` para enviar metadados ao seu backend.
-- **API pública**: após inicializar o widget, é possível utilizar `WhatsAppLeadWidget.open(number?)`, `WhatsAppLeadWidget.setNumber(number)` e `WhatsAppLeadWidget.destroy()`.
+- **API pública**: após inicializar o widget, é possível utilizar `WhatsAppLeadWidget.open(number?)`, `WhatsAppLeadWidget.setNumber(number)`, `WhatsAppLeadWidget.close()` e `WhatsAppLeadWidget.destroy()`.
+- **Acessibilidade aprimorada**: o modal possui foco aprisionado e pode ser fechado com a tecla `Esc`, além de melhor suporte para leitores de tela.
 
 ## Desenvolvimento
 


### PR DESCRIPTION
## Summary
- add accessibility and focus-trap improvements to the widget, expose a public close API, and prevent duplicate style injection
- strengthen the lead submission flow with native validation, resilient fetch handling, and a fallback when pop-ups are blocked
- document the new API surface and accessibility enhancements in the README

## Testing
- Manual: opened `example/index.html` and interacted with the widget

------
https://chatgpt.com/codex/tasks/task_e_68dbb797429c8328a0c285c7939e6ef0