### PR TITLE
Improve form validation feedback

### DIFF
--- a/src/whatsapp-lead-widget.js
+++ b/src/whatsapp-lead-widget.js
@@ -373,19 +373,32 @@
         $("#wlw-consent", this.modal)
       );
       const submitBtn = $(".wlw-submit", this.modal);
+      const form = /** @type {HTMLFormElement|null} */ (
+        $(".wlw-form", this.modal)
+      );
 
       const name = nameInput?.value.trim() || "";
       const email = emailInput?.value.trim() || "";
       const consent = consentInput?.checked ? "Sim" : "Não";
 
-      if (!name || !email) {
-        alert(this.config.texts.required);
-        return;
+      if (nameInput) {
+        nameInput.value = name;
+        if (typeof nameInput.setCustomValidity === "function") {
+          nameInput.setCustomValidity("");
+        }
+      }
+      if (emailInput) {
+        emailInput.value = email;
+        if (typeof emailInput.setCustomValidity === "function") {
+          emailInput.setCustomValidity("");
+        }
       }
 
-      if (email && !/^\S+@\S+\.\S+$/.test(email)) {
-        alert(this.config.texts.invalidEmail);
-        emailInput?.focus();
+      if (emailInput && email && !/^\S+@\S+\.\S+$/.test(email)) {
+        emailInput.setCustomValidity(this.config.texts.invalidEmail);
+      }
+
+      if (form && !form.reportValidity()) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- replace alert-based validation with HTML form constraint feedback in the widget form
- normalize input values before validation and reuse the configured invalid email message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5554404c8328a0af2f7c68f613e4