### PR TITLE
Capture tracking params in lead payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Caso queira deixar, por exemplo, o telefone opcional ao mesmo tempo em que mant�
 - **Theme**: personalize cores de destaque, hover e elementos do formulário.
 - **Interceptação de links**: habilite `interceptLinks: true` para que links `wa.me`, `api.whatsapp.com/send` e `whatsapp://send` abram o widget antes da conversa.
 - **Campos extras**: adicione pares chave/valor em `extraFields` para enviar metadados ao seu backend.
+- **Captação automática de UTMs**: quando presentes na URL, `utm_source`, `utm_medium`, `utm_campaign`, `gclid`, `fbclid`, além de `page_url` e `referrer`, são enviados automaticamente no payload do formulário.
 - **Pré-preenchimento e persistência**: utilize `prefill` para carregar dados iniciais e `storageKey` com `storageExpirationMinutes`
   para guardar as informações do visitante no `localStorage`.
 - **API pública**: após inicializar o widget, é possível utilizar `WhatsAppLeadWidget.open(number?)`, `WhatsAppLeadWidget.setNumber(number)`, `WhatsAppLeadWidget.close()` e `WhatsAppLeadWidget.destroy()`.

--- a/src/whatsapp-lead-widget.js
+++ b/src/whatsapp-lead-widget.js
@@ -77,6 +77,40 @@
     return output;
   };
 
+  const TRACKING_PARAMS = [
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "gclid",
+    "fbclid",
+  ];
+
+  const collectTrackingData = () => {
+    const trackingData = {};
+    const search = global.location?.search || "";
+    if (search && typeof URLSearchParams === "function") {
+      const params = new URLSearchParams(search);
+      TRACKING_PARAMS.forEach((key) => {
+        const value = params.get(key);
+        if (value) {
+          trackingData[key] = value;
+        }
+      });
+    }
+
+    const pageUrl = global.location?.href || "";
+    if (pageUrl) {
+      trackingData.page_url = pageUrl;
+    }
+
+    const referrer = global.document?.referrer || "";
+    if (referrer) {
+      trackingData.referrer = referrer;
+    }
+
+    return trackingData;
+  };
+
   /**
    * Simplifica o disparo de logs.
    * @param {"log"|"warn"|"error"} level
@@ -507,17 +541,20 @@
       const popup = global.open(waUrl, "_blank");
 
       const payload = mergeDeep(
-        {
-          nome: name,
-          email,
-          telefone: phone,
-          consent,
-          timestamp: new Date().toLocaleString("pt-BR", {
-            timeZone: "America/Sao_Paulo",
-          }),
-          userAgent: global.navigator?.userAgent || "",
-          pageUrl: global.location?.href || "",
-        },
+        mergeDeep(
+          {
+            nome: name,
+            email,
+            telefone: phone,
+            consent,
+            timestamp: new Date().toLocaleString("pt-BR", {
+              timeZone: "America/Sao_Paulo",
+            }),
+            userAgent: global.navigator?.userAgent || "",
+            pageUrl: global.location?.href || "",
+          },
+          collectTrackingData()
+        ),
         this.config.extraFields || {}
       );
 


### PR DESCRIPTION
## Summary
- collect UTM and click identifier parameters from the page URL and include them in the lead payload
- expose page URL and referrer alongside existing metadata and document the behaviour in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6cefb49c83288add58b559f758fc