### PR TITLE
Handle lead submission errors from backend

### DIFF
--- a/src/whatsapp-lead-widget.js
+++ b/src/whatsapp-lead-widget.js
@@ -666,7 +666,20 @@
       return fetch(this.config.scriptURL, {
         method: "POST",
         body: formData,
-      }).then((response) => response.text());
+      }).then(async (response) => {
+        const text = await response.text();
+        if (!response.ok) {
+          if (text) {
+            log("error", "Falha ao enviar lead", response.status, text);
+          }
+          const message = text?.trim() || `Request failed with status ${response.status}`;
+          throw new Error(message);
+        }
+        if (text) {
+          log("log", "Resposta do backend", text);
+        }
+        return text;
+      });
     }
 
     /** Dispara evento GA4, se configurado. */


### PR DESCRIPTION
## Summary
- inspect the lead submission response before resolving
- throw an error with the backend-provided message on non-2xx statuses
- log the backend response text to help diagnose issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68decfac10108328a33316845b37f4c3