### PR TITLE
Capture widget origin when posting lead data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Este repositório contém um modelo de Google Apps Script para integrar uma planilha do Google com aplicações externas via Web App. Copie o conteúdo de `apps-script.gs` para o editor do Apps Script vinculado à sua planilha e ajuste as configurações conforme necessário.
+Este repositório contém um modelo de Google Apps Script para integrar uma planilha do Google com aplicações externas via Web App. Copie o conteúdo de `apps-script.gs` para o editor do Apps Script vinculado à sua planilha e ajuste as configurações conforme necessário. No objeto `CONFIG`, informe em `allowOrigins` o domínio que hospedará o widget (por exemplo, `https://seu-dominio.com`) e/ou `'*'` para permitir qualquer origem, garantindo que a validação de CORS aceite as requisições enviadas.
 =======
 # WhatsApp Lead Widget
 

--- a/apps-script.gs
+++ b/apps-script.gs
@@ -7,6 +7,9 @@
 const CONFIG = {
   spreadsheetId: 'REPLACE_WITH_SPREADSHEET_ID',
   sheetName: 'Sheet1',
+  // Informe os domínios autorizados a consumir o Web App. Inclua aqui o
+  // domínio enviado pelo widget (global.location.origin) e/ou '*' para
+  // permitir qualquer origem.
   allowOrigins: ['https://seu-dominio.com', 'http://localhost:3000'],
 };
 

--- a/src/whatsapp-lead-widget.js
+++ b/src/whatsapp-lead-widget.js
@@ -656,6 +656,7 @@
     /** Envia os dados ao backend se `scriptURL` estiver configurado. */
     _postLead(payload) {
       if (!this.config.scriptURL) return Promise.resolve("skipped");
+      const origin = global.location?.origin;
       const formData = new FormData();
       Object.keys(payload).forEach((key) => {
         const value = payload[key];
@@ -663,6 +664,9 @@
           formData.append(key, value);
         }
       });
+      if (origin) {
+        formData.append("origin", origin);
+      }
       return fetch(this.config.scriptURL, {
         method: "POST",
         body: formData,


### PR DESCRIPTION
## Summary
- include the page origin in lead submissions so the backend can validate it against the CORS configuration
- document how to configure `CONFIG.allowOrigins` to accept the origin sent by the widget

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa760c3348328b261341a94ae84ff