### PR TITLE
Handle sheet retrieval errors in web app endpoints

### DIFF
--- a/apps-script.gs
+++ b/apps-script.gs
@@ -73,23 +73,28 @@ function maybeHandleOptions(e) {
  * @param {GoogleAppsScript.Events.DoGet} e
  */
 function doGet(e) {
-  const sheet = getSheet();
-  const data = sheet.getDataRange().getDisplayValues();
-  const [header, ...rows] = data;
+  try {
+    const sheet = getSheet();
+    const data = sheet.getDataRange().getDisplayValues();
+    const [header, ...rows] = data;
 
-  const json = rows.map(function(row) {
-    return header.reduce(function(acc, key, index) {
-      acc[key] = row[index];
-      return acc;
-    }, {});
-  });
+    const json = rows.map(function(row) {
+      return header.reduce(function(acc, key, index) {
+        acc[key] = row[index];
+        return acc;
+      }, {});
+    });
 
-  const output = ContentService
-    .createTextOutput(JSON.stringify({ data: json }))
-    .setMimeType(ContentService.MimeType.JSON);
+    const output = ContentService
+      .createTextOutput(JSON.stringify({ data: json }))
+      .setMimeType(ContentService.MimeType.JSON);
 
-  applyCors(e, output);
-  return output;
+    applyCors(e, output);
+    return output;
+  } catch (error) {
+    const message = (error && error.message) ? error.message : 'Failed to access sheet.';
+    return buildErrorResponse(e, 500, message);
+  }
 }
 
 /**
@@ -147,18 +152,23 @@ function doPost(e) {
     }
   }
 
-  const sheet = getSheet();
-  const headers = sheet.getDataRange().getValues()[0];
-  const row = headers.map(function(key) { return payload[key] || ''; });
+  try {
+    const sheet = getSheet();
+    const headers = sheet.getDataRange().getValues()[0];
+    const row = headers.map(function(key) { return payload[key] || ''; });
 
-  sheet.appendRow(row);
+    sheet.appendRow(row);
 
-  const output = ContentService
-    .createTextOutput(JSON.stringify({ success: true }))
-    .setMimeType(ContentService.MimeType.JSON);
+    const output = ContentService
+      .createTextOutput(JSON.stringify({ success: true }))
+      .setMimeType(ContentService.MimeType.JSON);
 
-  applyCors(e, output);
-  return output;
+    applyCors(e, output);
+    return output;
+  } catch (error) {
+    const message = (error && error.message) ? error.message : 'Failed to access sheet.';
+    return buildErrorResponse(e, 500, message);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- wrap doGet and doPost sheet access in try/catch blocks
- return standardized error responses when sheet access fails so CORS headers are applied

## Testing
- not run (Apps Script code change)

------
https://chatgpt.com/codex/tasks/task_e_68dfb11d057c8328bf1a7baaacb7e0a0