### PR TITLE
Document minimal Apps Script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,22 +98,44 @@ Depois de colar o conteúdo do arquivo `apps-script.gs` no editor do Apps Script
 
 ```js
 function doPost(e) {
-  const payload = {
-    nome: e.parameter.nome,
-    email: e.parameter.email,
-    telefone: e.parameter.telefone,
-    consent: e.parameter.consent === 'true',
-    timestamp: new Date(),
-    userAgent: e.parameter.userAgent,
-    pageUrl: e.parameter.pageUrl,
-    userIP: e.parameter.userIP,
-  };
+  try {
+    var sheet = SpreadsheetApp
+      .openById('SUA_PLANILHA_ID')
+      .getSheetByName('Leads');
 
-  appendToSheet_(payload);
+    if (!sheet) {
+      throw new Error('Aba "Leads" não encontrada.');
+    }
 
-  return ContentService.createTextOutput(
-    JSON.stringify({ success: true })
-  ).setMimeType(ContentService.MimeType.JSON);
+    var nome = e.parameter.nome || '';
+    var email = e.parameter.email || '';
+    var telefone = e.parameter.telefone || '';
+    var consent = e.parameter.consent === 'true';
+    var timestamp = new Date();
+    var userAgent = e.parameter.userAgent || '';
+    var pageUrl = e.parameter.pageUrl || '';
+    var userIP = e.parameter.userIP || '';
+
+    // Ajuste a ordem/quantidade de colunas conforme o cabeçalho da sua planilha.
+    sheet.appendRow([
+      nome,
+      email,
+      telefone,
+      consent,
+      timestamp,
+      userAgent,
+      pageUrl,
+      userIP,
+    ]);
+
+    return ContentService.createTextOutput(
+      JSON.stringify({ success: true })
+    ).setMimeType(ContentService.MimeType.JSON);
+  } catch (error) {
+    return ContentService.createTextOutput(
+      JSON.stringify({ success: false, message: String(error) })
+    ).setMimeType(ContentService.MimeType.JSON);
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- replace the README snippet with a fully self-contained `doPost` example based on `e.parameter`
- highlight how to adjust the sheet columns when using the minimal flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb368b2fc8328aa75a85fff46021b