### PR TITLE
Adjust default sheet column mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ da sua planilha, preencha as chaves de configuração (`spreadsheetId`, `sheetNa
 1. Acesse o [Google Sheets](https://docs.google.com/spreadsheets/) e crie uma nova planilha em branco.
 2. Renomeie a aba principal para algo fácil de identificar, por exemplo `Leads`.
 3. Na linha de cabeçalho (células `A1` em diante), preencha os rótulos exatamente na mesma ordem definida em `CONFIG.columns` do
-   arquivo `apps-script.gs`. O modelo padrão considera: `timestamp`, `nome`, `email`, `telefone`, `consent`, `userAgent`,
-   `pageUrl`, `userIP`, `gbraid`, `wbraid`.
-4. Caso deseje armazenar outros metadados enviados pelo widget, adicione novas colunas após `wbraid` e inclua objetos
+   arquivo `apps-script.gs`. O modelo padrão considera: `nome`, `email`, `telefone`, `consent`, `timestamp`, `data/hora da ação`,
+   `userAgent`, `pageUrl`, `gclid`, `fbclid`, `gbraid`, `wbraid`, `utm_source`, `utm_medium`, `utm_campaign`, `referrer`,
+   `page_url`, `userIP`.
+4. Caso deseje armazenar outros metadados enviados pelo widget, adicione novas colunas após `userIP` e inclua objetos
    correspondentes no array `columns` (ex.: `{ key: 'minhaChave' }`).
 5. Compartilhe a planilha com o mesmo usuário que será utilizado no Google Apps Script (ou defina permissões conforme necessário)
    para garantir que o script possa gravar os dados.

--- a/apps-script.gs
+++ b/apps-script.gs
@@ -23,16 +23,35 @@ const CONFIG = {
    * Ajuste conforme o cabeçalho configurado no Sheets.
    * @type {Array<{ key?: string, value?: (params: GoogleAppsScript.Events.DoPost['parameter']) => any, transform?: (value: any, params: GoogleAppsScript.Events.DoPost['parameter']) => any }>} */
   columns: [
-    { value: function () { return new Date(); } }, // timestamp da submissão
     { key: 'nome' },
     { key: 'email' },
     { key: 'telefone' },
-    { key: 'consent', transform: function (value) { return value === 'true' || value === true; } },
+    {
+      key: 'consent',
+      transform: function (value) {
+        if (value === 'Sim' || value === 'true' || value === true) {
+          return true;
+        }
+        if (value === 'Não' || value === 'false' || value === false) {
+          return false;
+        }
+        return value;
+      },
+    },
+    { key: 'timestamp' },
+    { key: 'data/hora da ação' },
     { key: 'userAgent' },
     { key: 'pageUrl' },
-    { key: 'userIP' },
+    { key: 'gclid' },
+    { key: 'fbclid' },
     { key: 'gbraid' },
     { key: 'wbraid' },
+    { key: 'utm_source' },
+    { key: 'utm_medium' },
+    { key: 'utm_campaign' },
+    { key: 'referrer' },
+    { key: 'page_url' },
+    { key: 'userIP' },
   ],
 };
 


### PR DESCRIPTION
## Summary
- reorder the default Apps Script column mapping to keep lead data aligned with sheet headers and add tracking fields such as gclid and fbclid
- update the README instructions to reflect the new default column order and extension guidance

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68dfb72e28dc832886f14a5e1f38e34e