### PR TITLE
Ensure close button padding overrides Elementor styles

### DIFF
--- a/src/whatsapp-lead-widget.js
+++ b/src/whatsapp-lead-widget.js
@@ -271,7 +271,7 @@
       .wlw-avatar { width: 44px; height: 44px; border-radius: 50%; object-fit: cover; background: rgba(255,255,255,0.2); }
       .wlw-title { font-size: 17px; font-weight: 700; line-height: 1.2; }
       .wlw-status { font-size: 13px; color: #c8f8c8; }
-      .wlw-close { position: absolute !important; top: 10px !important; right: 10px !important; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; cursor: pointer; font-size: 22px; line-height: 1; color: #fff !important; background: transparent !important; border: none !important; border-radius: 4px; box-shadow: none !important; padding: 0; appearance: none; }
+      .wlw-close { position: absolute !important; top: 12px !important; right: 12px !important; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; cursor: pointer; font-size: 22px; line-height: 1; color: #fff !important; background: transparent !important; border: none !important; border-radius: 4px; box-shadow: none !important; padding: 0 !important; appearance: none; }
       .wlw-body { background: ${t.bubbleBg} url('${cfg.backgroundPattern}') repeat; background-size: 300px; padding: 12px; }
       .wlw-msg { background: #fff; border: 1px solid #cacaca; border-radius: 6px; padding: 10px; color: #4a4a4a; margin-bottom: 10px; font-size: 14px; line-height: 1.5; }
       .wlw-form { display: flex; flex-direction: column; }


### PR DESCRIPTION
## Summary
- force the close button to ignore Elementor's default button padding by marking the widget's padding reset as !important

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e32718dc8328b21d4e4485aa7472