### PR TITLE
Call prefill when opening widget

### DIFF
--- a/src/whatsapp-lead-widget.js
+++ b/src/whatsapp-lead-widget.js
@@ -758,6 +758,8 @@
         this.runtimeNumber = this.config.whatsappNumber;
       }
 
+      this._applyPrefill();
+
       this.modal.style.display = "block";
       this.fab?.setAttribute("aria-expanded", "true");
       const nameInput = $("#wlw-name", this.modal);


### PR DESCRIPTION
## Summary
- trigger `_applyPrefill` whenever the widget is opened so stored field values are restored before focusing inputs

## Testing
- not run (manual browser-based verification unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e109f80048832884a4e99c4cc474b7