### PR TITLE
Document local storage configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ function doPost(e) {
 
 Um exemplo completo está disponível em [`example/index.html`](example/index.html). Abra o arquivo direto no navegador para testar a experiência.
 
+### Persistência local dos dados do visitante
+
+O widget pode salvar temporariamente as informações preenchidas pelo visitante usando o `localStorage` do navegador. Para ativar
+esse comportamento, informe uma string na propriedade `storageKey`. O valor representa a chave utilizada para gravar e recuperar
+os dados do formulário.
+
+- `storageKey`: define a chave onde o widget armazena o JSON com os dados coletados. Quando presente, o widget tenta resgatar
+  automaticamente o conteúdo salvo na próxima abertura do modal.
+- `storageExpirationMinutes`: controla por quanto tempo (em minutos) os dados permanecem válidos. O valor padrão é 1440
+  minutos (24 horas). Após esse período, a chave é descartada e um novo preenchimento será solicitado.
+
+Em aplicações que utilizam múltiplos widgets simultaneamente (por exemplo, um para vendas e outro para suporte), configure um
+`storageKey` exclusivo para cada instância, evitando que os dados de um formulário sejam aplicados ao outro. Uma convenção útil é
+combinar o nome do projeto com o contexto do widget, como `"minha-app-vendas"` e `"minha-app-suporte"`.
+
 ## Personalização
 
 - **Texts**: altere rótulos, mensagens e textos exibidos no modal.

--- a/example/index.html
+++ b/example/index.html
@@ -105,6 +105,9 @@
         privacyPolicyUrl: "https://exemplo.com/politica",
         interceptLinks: true,
         enableGA4: true,
+        // Armazena os dados preenchidos no localStorage por 24 horas.
+        storageKey: "wlw-leads",
+        storageExpirationMinutes: 60 * 24,
         contactFields: {
           email: { enabled: true, required: false },
           phone: { enabled: true, required: true }


### PR DESCRIPTION
## Summary
- document how to enable local persistence with storageKey and storageExpirationMinutes in the README
- add guidance for choosing unique storage keys when multiple widgets coexist
- update the example widget configuration to demonstrate a storageKey value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e10a084c908328a8dbf51999e5d6e8