### PR TITLE
Set indefinite default storage expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,12 @@ os dados do formulário.
 
 - `storageKey`: define a chave onde o widget armazena o JSON com os dados coletados. Quando presente, o widget tenta resgatar
   automaticamente o conteúdo salvo na próxima abertura do modal.
-- `storageExpirationMinutes`: controla por quanto tempo (em minutos) os dados permanecem válidos. O valor padrão é 1440
-  minutos (24 horas). Após esse período, a chave é descartada e um novo preenchimento será solicitado.
+- `storageExpirationMinutes`: controla por quanto tempo (em minutos) os dados permanecem válidos. O valor padrão é `0`, ou
+  seja, os registros não expiram e permanecem disponíveis até que o visitante limpe o armazenamento do navegador. Defina um
+  número positivo caso queira que o widget descarte as informações após determinado período.
+
+Mesmo com armazenamento sem prazo, o visitante pode atualizar os dados a qualquer momento: basta editar o formulário e
+enviar novamente, e o widget sobrescreverá o conteúdo salvo.
 
 Em aplicações que utilizam múltiplos widgets simultaneamente (por exemplo, um para vendas e outro para suporte), configure um
 `storageKey` exclusivo para cada instância, evitando que os dados de um formulário sejam aplicados ao outro. Uma convenção útil é

--- a/example/index.html
+++ b/example/index.html
@@ -105,9 +105,9 @@
         privacyPolicyUrl: "https://exemplo.com/politica",
         interceptLinks: true,
         enableGA4: true,
-        // Armazena os dados preenchidos no localStorage por 24 horas.
+        // Mantém os dados preenchidos no localStorage sem expiração.
         storageKey: "wlw-leads",
-        storageExpirationMinutes: 60 * 24,
+        storageExpirationMinutes: 0,
         contactFields: {
           email: { enabled: true, required: false },
           phone: { enabled: true, required: true }

--- a/src/whatsapp-lead-widget.js
+++ b/src/whatsapp-lead-widget.js
@@ -169,7 +169,7 @@
     theme: DEFAULT_THEME,
     prefill: null,
     storageKey: null,
-    storageExpirationMinutes: 60 * 24,
+    storageExpirationMinutes: 0,
     contactFields: DEFAULT_CONTACT_FIELDS,
   };
 


### PR DESCRIPTION
## Summary
- set the widget's default storage expiration to 0 so saved leads stay available indefinitely
- refresh documentation and example config to reflect the new default and clarify how to update stored data

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e10b6733f88328800a05d6ae4bbf7c