### PR TITLE
fix: lead-save best-effort nao fecha o WhatsApp nem alerta em falha

### DIFF
--- a/src/whatsapp-lead-widget.js
+++ b/src/whatsapp-lead-widget.js
@@ -546,7 +546,7 @@
         phone,
         consent === "Sim"
       );
-      const popup = global.open(waUrl, "_blank");
+      global.open(waUrl, "_blank");
 
       const actionDate = new Date();
       const formattedActionDate = actionDate.toLocaleString("pt-BR", {
@@ -570,30 +570,30 @@
 
       dispatchEvent(this.modal, "submit", payload);
 
+      // O WhatsApp ja foi aberto acima. A partir daqui o registro do lead e
+      // best-effort: qualquer falha no envio (CSP, instabilidade do Apps
+      // Script, quirk de CORS no Safari/iOS) NAO deve fechar o WhatsApp nem
+      // alertar o usuario. Chegar na conversa e o objetivo; gravar o lead e
+      // secundario. Por isso o try/catch envolve so o envio e engole o erro.
       try {
         const ip = await this._getUserIP();
         if (ip) payload.userIP = ip;
         await this._postLead(payload);
+        dispatchEvent(this.modal, "success", payload);
+      } catch (error) {
+        log("error", "Falha no lead-save (best-effort, WhatsApp ja aberto)", error);
+        dispatchEvent(this.modal, "error", { error });
+        // Intencional: sem alert() e sem fechar o WhatsApp. Ver comentario acima.
+      } finally {
+        // O clique de WhatsApp aconteceu independente do lead-save — registra
+        // o evento, limpa e fecha o modal, e reabilita o botao em qualquer caso.
         this._trackGA("whatsappClick", {
           event_category: "engagement",
           event_label: "WhatsApp Form",
           value: 1,
         });
-        dispatchEvent(this.modal, "success", payload);
         this._resetForm();
         this.close();
-      } catch (error) {
-        log("error", "Erro ao enviar dados", error);
-        dispatchEvent(this.modal, "error", { error });
-        alert("Ocorreu um erro ao enviar os dados. Tente novamente.");
-        if (popup) {
-          try {
-            popup.close();
-          } catch (_) {
-            /* noop */
-          }
-        }
-      } finally {
         if (submitBtn) {
           submitBtn.removeAttribute("disabled");
           submitBtn.textContent = this.config.texts.submit;


### PR DESCRIPTION
## Problema

O widget abre o WhatsApp (`global.open`) **antes** de enviar o lead ao backend. Quando o envio async falhava (CSP bloqueando o fetch, instabilidade do Apps Script, quirk de CORS no Safari/iOS), o `catch` fazia `alert("Ocorreu um erro...")` **e `popup.close()`** — derrubando a aba do WhatsApp que tinha acabado de abrir.

No desktop isso era visivel (quebra na cara do usuario). No mobile, o app do WhatsApp ja tinha assumido e a falha ficava invisivel — o que fazia o bug parecer **intermitente/por-dispositivo**.

## Correcao

Registrar o lead passa a ser **best-effort**:

- O `try/catch` envolve **so o envio**; o erro e engolido (mantem `log` + evento `error` pra telemetria), **sem `alert` e sem fechar o WhatsApp**.
- `_trackGA("whatsappClick")`, `_resetForm()`, `close()` e reabilitar o botao vao pro `finally` — rodam em qualquer caso (o clique de WhatsApp aconteceu independente do lead-save).
- Removida a variavel `popup`, que deixou de ser usada.

A logica de captura de lead nao muda: com o backend de pe, o lead e salvo igual. So deixa de ser ponto unico de falha que sabota o objetivo principal (chegar na conversa).

Sintaxe validada com `node --check`.