### PR TITLE
fix: fire GA4 whatsappClick before async fetch (~31% event loss)

### DIFF
--- a/src/whatsapp-lead-widget.js
+++ b/src/whatsapp-lead-widget.js
@@ -570,6 +570,17 @@
 
       dispatchEvent(this.modal, "submit", payload);
 
+      // Registra a conversao GA4 aqui — antes de qualquer await — para garantir
+      // o disparo mesmo que o usuario feche a aba ao ser redirecionado para o
+      // WhatsApp. Como nao ha await entre o clique do usuario e este ponto, o
+      // evento ainda esta sincrono com o gesto, o que tambem evita o bloqueio
+      // de popup do Safari/iOS no window.open acima.
+      this._trackGA("whatsappClick", {
+        event_category: "engagement",
+        event_label: "WhatsApp Form",
+        value: 1,
+      });
+
       // O WhatsApp ja foi aberto acima. A partir daqui o registro do lead e
       // best-effort: qualquer falha no envio (CSP, instabilidade do Apps
       // Script, quirk de CORS no Safari/iOS) NAO deve fechar o WhatsApp nem
@@ -585,13 +596,6 @@
         dispatchEvent(this.modal, "error", { error });
         // Intencional: sem alert() e sem fechar o WhatsApp. Ver comentario acima.
       } finally {
-        // O clique de WhatsApp aconteceu independente do lead-save — registra
-        // o evento, limpa e fecha o modal, e reabilita o botao em qualquer caso.
-        this._trackGA("whatsappClick", {
-          event_category: "engagement",
-          event_label: "WhatsApp Form",
-          value: 1,
-        });
         this._resetForm();
         this.close();
         if (submitBtn) {


### PR DESCRIPTION
## Problema

O evento `whatsappClick` era disparado no bloco `finally` do `_handleSubmit`, ou seja, **só depois** de:
1. `_getUserIP()` (~800ms de timeout)
2. `_postLead()` (POST para o Apps Script)

Como o widget já abre o WhatsApp via `window.open` antes dessas operações async, o usuário normalmente fecha/abandona a aba original. Resultado: ~31% dos leads chegavam na planilha mas **não eram registrados no GA4**.

## Correção

Move `_trackGA("whatsappClick", {...})` para **antes** do bloco `try/await` — logo após `dispatchEvent(submit)` e antes de qualquer `await`. Nesse ponto não há nenhuma operação assíncrona entre o clique do usuário e o evento GA4, então:

- O evento dispara **sempre**, independente de o usuário fechar a aba
- Mantém o `window.open` e o tracking **síncronos com o gesto do usuário**, evitando o bloqueio de popup no iOS Safari

O bloco `finally` continua existindo para limpar o formulário e fechar o modal.

## Tag

Esta branch foi taggeada como `v0.4`. Para usar no site:

```html
<script src="https://cdn.jsdelivr.net/gh/pedrolicio/Widget-Whatsapp@v0.4/src/whatsapp-lead-widget.js"></script>
```